### PR TITLE
Build live narration backend with beat detection

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -11,6 +11,7 @@ IMAGE_MODEL = os.getenv("GEMINI_IMAGE_MODEL", STORY_MODEL)
 TTS_LANGUAGE_CODE = os.getenv("TTS_LANGUAGE_CODE", "en-US")
 TTS_DEFAULT_VOICE = os.getenv("TTS_DEFAULT_VOICE", "en-US-Standard-F")
 TTS_MAX_CHARS_PER_REQUEST = int(os.getenv("TTS_MAX_CHARS_PER_REQUEST", "1800"))
+NARRATION_BEAT_THRESHOLD = int(os.getenv("NARRATION_BEAT_THRESHOLD", "150"))
 PORT = int(os.getenv("PORT", 8080))
 
 SYSTEM_INSTRUCTION = """You are Luminary, a master cinematic storyteller.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from contextlib import asynccontextmanager
@@ -141,6 +142,27 @@ async def ws_story(websocket: WebSocket, sid: str):
         await websocket.close(); return
     logger.info("WebSocket connected for session_id={}", sid)
     await websocket.send_json({"type":"system","content":f"Connected: {session.title}"})
+
+    async def emit(payload: dict):
+        try:
+            await websocket.send_json(payload)
+        except Exception:
+            logger.debug("Dropped narration event for closed socket session_id={}", sid)
+
+    async def narration_beat(force: bool):
+        try:
+            await story_service.run_narration_beat(session, emit, force=force)
+        except Exception as exc:
+            logger.exception("Narration beat failed for session_id={}: {}", sid, exc)
+            await emit({"type": "error", "content": format_model_error(exc)})
+
+    narration_tasks: set[asyncio.Task] = set()
+
+    def spawn_narration_beat(force: bool):
+        task = asyncio.create_task(narration_beat(force))
+        narration_tasks.add(task)
+        task.add_done_callback(narration_tasks.discard)
+
     try:
         while True:
             data = await websocket.receive_json()
@@ -160,6 +182,20 @@ async def ws_story(websocket: WebSocket, sid: str):
                     logger.error("Story turn failed for session_id={}: {}", sid, result["error"])
                     await websocket.send_json({"type":"error","content":result["error"]})
                 await websocket.send_json({"type":"status","content":"complete"})
+            elif data.get("type") == "narration":
+                chunk = (data.get("content") or "").strip()
+                if chunk:
+                    session.narration_pending = (
+                        f"{session.narration_pending} {chunk}".strip()
+                        if session.narration_pending else chunk
+                    )
+                    # Beat runs in the background so the receive loop keeps
+                    # accepting chunks; the per-session lock in the service
+                    # prevents overlapping generations.
+                    if not session.narration_lock.locked():
+                        spawn_narration_beat(False)
+            elif data.get("type") == "narration_flush":
+                spawn_narration_beat(True)
             elif data.get("type")=="ping":
                 await websocket.send_json({"type":"pong"})
     except WebSocketDisconnect:

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
+import asyncio
 import uuid
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -40,6 +41,7 @@ class StorySession:
     last_image: str | None = None
     last_image_mime: str | None = None
     narration_pending: str = ""
+    narration_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
 
     def snapshot(self) -> dict:
         return {

--- a/backend/story_service.py
+++ b/backend/story_service.py
@@ -5,10 +5,30 @@ import json
 from google.genai import types
 from loguru import logger
 
-from config import FALLBACK_MODEL, STORY_MODEL, SYSTEM_INSTRUCTION, TITLE_MODEL
+from config import (
+    FALLBACK_MODEL,
+    NARRATION_BEAT_THRESHOLD,
+    STORY_MODEL,
+    SYSTEM_INSTRUCTION,
+    TITLE_MODEL,
+)
 from gemini_utils import format_model_error
 from models import StoryEvent, StoryMemory, StorySession, StoryboardBeat
 from visual_engine import VisualEngine
+
+
+NARRATION_BEAT_PROMPT = (
+    "You listen to a live storyteller and decide when enough of a scene has been described to illustrate it. "
+    "Return strict JSON with keys: beat_complete, scene_prompt, caption, memory. "
+    "beat_complete: true only when the narration so far paints one coherent, visualizable scene "
+    "(a place, characters or subjects, and an action or mood). "
+    "scene_prompt: one vivid paragraph an illustrator can paint, grounded ONLY in what was narrated. "
+    "caption: a short storyboard caption (max 12 words). "
+    "memory: up to 5 objects with label and detail — durable story facts only "
+    "(characters, promises, secrets, objects, relationships, wounds, goals), merging the existing memory "
+    "with anything new from the narration.\n"
+    "Title: {title}\nGenre: {genre}\nExisting memory:\n{memory}\nNarration so far:\n{narration}"
+)
 
 
 class StoryService:
@@ -200,6 +220,115 @@ class StoryService:
 
     async def _generate_scene_image(self, session: StorySession, text_context: str) -> StoryEvent | None:
         return await self.visuals.generate_scene(session, text_context)
+
+    async def _detect_narration_beat(self, session: StorySession, narration: str) -> dict:
+        prompt = NARRATION_BEAT_PROMPT.format(
+            title=session.title,
+            genre=session.genre,
+            memory=self._build_memory_context(session),
+            narration=self._json_excerpt(narration, 2000),
+        )
+        try:
+            response = await self.client.aio.models.generate_content(
+                model=FALLBACK_MODEL,
+                contents=[{"role": "user", "parts": [{"text": prompt}]}],
+                config=types.GenerateContentConfig(
+                    temperature=0.2,
+                    max_output_tokens=600,
+                    response_mime_type="application/json",
+                ),
+            )
+            return self._parse_json_block(self._extract_text(response)) or {}
+        except Exception as exc:
+            logger.warning("Narration beat detection failed: {}", exc)
+            return {}
+
+    async def run_narration_beat(self, session: StorySession, emit, force: bool = False) -> bool:
+        """Illustrate the pending narration buffer once it forms a complete beat.
+
+        `emit` is an async callback receiving websocket-ready event dicts.
+        Returns True when a beat was illustrated. The per-session lock keeps
+        overlapping narration chunks from triggering concurrent generations;
+        chunks arriving mid-generation stay in the buffer for the next check.
+        """
+        if session.narration_lock.locked() and not force:
+            return False
+        async with session.narration_lock:
+            captured = session.narration_pending
+            narration = captured.strip()
+            if not narration:
+                return False
+            if not force and len(narration) < NARRATION_BEAT_THRESHOLD:
+                return False
+
+            payload = await self._detect_narration_beat(session, narration)
+            if not force and not payload.get("beat_complete"):
+                return False
+
+            # Consume only what we captured — chunks appended while the model
+            # calls below run remain buffered for the next beat.
+            session.narration_pending = session.narration_pending[len(captured):]
+            session.turns += 1
+            session.history.append(
+                {"role": "user", "parts": [{"text": f"[Live narration] {narration}"}]}
+            )
+
+            scene_prompt = (payload.get("scene_prompt") or "").strip() or narration
+            caption = (payload.get("caption") or "").strip() or self._json_excerpt(narration, 120)
+
+            await emit({"type": "status", "content": "illustrating"})
+            image_event = await self.visuals.generate_scene(session, scene_prompt)
+            if image_event:
+                session.history.append({"role": "model", "parts": [{"text": "[illustration]"}]})
+                await emit({
+                    "type": "image",
+                    "content": image_event.content,
+                    "mime_type": image_event.mime_type,
+                })
+
+            memory_items = payload.get("memory") or []
+            if memory_items:
+                session.memory = [
+                    StoryMemory(
+                        label=(item.get("label") or "Story thread")[:40],
+                        detail=(item.get("detail") or "").strip()[:180],
+                    )
+                    for item in memory_items[:5]
+                    if item.get("detail")
+                ]
+
+            session.storyboard.append(
+                StoryboardBeat(
+                    turn=session.turns,
+                    caption=caption[:120],
+                    image=image_event.content if image_event else None,
+                    mime_type=image_event.mime_type if image_event else None,
+                )
+            )
+            session.storyboard = session.storyboard[-8:]
+
+            await emit({
+                "type": "memory",
+                "items": [{"label": item.label, "detail": item.detail} for item in session.memory],
+            })
+            await emit({
+                "type": "storyboard",
+                "items": [
+                    {
+                        "turn": beat.turn,
+                        "caption": beat.caption,
+                        "image": beat.image,
+                        "mime_type": beat.mime_type,
+                    }
+                    for beat in session.storyboard
+                ],
+            })
+            await emit({"type": "status", "content": "beat_complete"})
+            logger.info(
+                "Narration beat illustrated for session_id={} turn={} (forced={})",
+                session.session_id, session.turns, force,
+            )
+            return True
 
     async def create_story(self, genre: str, premise: str, director_mode: str = "cinematic") -> dict:
         title_resp = await self.client.aio.models.generate_content(

--- a/backend/visual_engine.py
+++ b/backend/visual_engine.py
@@ -1,3 +1,7 @@
+
+
+
+
 """Visual continuity engine.
 
 Keeps every generated illustration in one session visually connected:


### PR DESCRIPTION

New hook frontend/src/hooks/useLiveNarration.js — continuous SpeechRecognition (continuous: true, interim results on), unlike the one-shot dictation hook. Browsers kill continuous recognition after silence, so onend spins up a fresh recognition instance for as long as narration is active (restarting a dead instance is unreliable, so it always recreates). It exposes interimTranscript for live display and fires onChunk for each finalized transcript piece. Permission errors (not-allowed) stop the session for real; transient errors like no-speech just flow into the auto-restart. Unmount cleanup stops the mic.                      
New hook frontend/src/hooks/useLiveNarration.js — continuous SpeechRecognition (continuous: true, interim results on), unlike the    one-shot dictation hookcognition after silence, so onend spins up a fresh recognition instance for as long as narration is active (restarting a dead instance is unreliable, so it always recreatesIt exposes interimTransres onChunk for eachfinalized transcript piece. Permission errors (not-allowed) stop the session for real; transient errors like no-speech just flow into the auto-restarUnmount cleanup stops tnarration segment (contiguous chunks merge into one paragraph until an illustration lands, then a new paragraph starts) and sends {type: "narration"} over the existing WS. flushNarration() sends {type: "narration_flush"}.
- If the socket is reconnecting, narration payloads queue in pendingNarrationRef and flush on open, same pattern as choices.
- New narrationStatus state driven by the backend's status: illustrating / beat_complete events; beat_complete also bumps saveVersion, so narration beats trigger the same snapshot sync as choice turns — narrated prose and its images persist and restore.

Story.jsx + CSS:
- A prominent narrate bar sits above the story feed: a gold "Narrate live" pill that turns green with a pulsing mic dot while recording, plus a hinline that switches to "beat renders.
- While narrating, finalized speech streams into the feed as italic "You narrate" prose, with a dashed live card showing the interim             (still-being-spoken) trbtle green "Painting the scene…" indicator when the backend is illustrating — nothing blocks; you keep talking.                                                           - Illustration cards noion), so beat imagesappear softly beside the narration.
- Stop narrating → the mic closes and flushNarration() forces the final image from whatever's l
- Mode coexistence: while narrating, choices, the director textarea/submit, and the one-shot dictation button are disabled (dictation would fight over the mic); the narrate toggle is likewise disabled while dictating or while a choice turn is streaming. When the mic is off, everything works exactly as before.
